### PR TITLE
Translate class members lazily

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "xblock_qualtrics_survey",
   "title": "Qualtrics Survey",
   "description": "Xblock for creating a Qualtrics survey.",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "homepage": "https://github.com/Stanford-Online/xblock-qualtrics-survey",
   "author": {
     "name": "David Adams",

--- a/qualtricssurvey/qualtricssurvey.py
+++ b/qualtricssurvey/qualtricssurvey.py
@@ -5,7 +5,7 @@ import os
 import cgi
 import pkg_resources
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from xblock.core import XBlock
 from xblock.fields import Scope


### PR DESCRIPTION
Since these lines are actually evaluated at build/startup time, we need
to defer the translation until runtime.

Otherwise, later versions of Django throw a fit:

> AppRegistryNotReady: The translation infrastructure cannot be
> initialized before the apps registry is ready. Check that you don't
> make non-lazy gettext calls at import time.