### PR TITLE
Stop translating display_name

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "xblock_qualtrics_survey",
   "title": "Qualtrics Survey",
   "description": "Xblock for creating a Qualtrics survey.",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "homepage": "https://github.com/Stanford-Online/xblock-qualtrics-survey",
   "author": {
     "name": "David Adams",

--- a/qualtricssurvey/qualtricssurvey.py
+++ b/qualtricssurvey/qualtricssurvey.py
@@ -20,7 +20,7 @@ class QualtricsSurvey(StudioEditableXBlockMixin, XBlock):
     """
     display_name = String(
         display_name=_('Display Name:'),
-        default=_('Qualtrics Survey'),
+        default='Qualtrics Survey',
         scope=Scope.settings,
         help=_(
             'This name appears in the horizontal navigation at the top '


### PR DESCRIPTION
Because display_name is used in other contexts, like Outlines,
(outside of normal template rendering) lazy translations lead to a
number of issues localizing/rendering the value.

Since this is just used to seed the default value first displayed to the
instructor in Studio [1], and doesn't affect LMS translation, there
shouldn't be a reason we need to try localizing at this level.

This follows the lead set by the ORA2 XBlock.

- [1] Studio only explicitly supports English.